### PR TITLE
Add recent scans overview page

### DIFF
--- a/website/image_server_web/view_recent_scans.php
+++ b/website/image_server_web/view_recent_scans.php
@@ -1,0 +1,44 @@
+<?php
+require_once('worm_environment.php');
+
+try{
+  // Retrieve all non-simulated devices
+  $query = "SELECT name FROM devices WHERE simulated_device = 0 ORDER BY name ASC";
+  $sql->get_row($query,$devices);
+
+  display_worm_page_header("Recent Scanner Activity");
+
+  foreach($devices as $d){
+    $device_name = $d[0];
+    echo "<h3 id=\"d$device_name\">$device_name</h3>";
+
+    // Get the four most recent captured images for this device
+    $image_query = "SELECT c.image_id, c.small_image_id, c.capture_time "
+      . "FROM captured_images AS c, capture_samples AS s "
+      . "WHERE c.sample_id = s.id AND s.device_name = '$device_name' AND c.small_image_id != 0 "
+      . "ORDER BY c.capture_time DESC LIMIT 4";
+    $sql->get_row($image_query,$images);
+
+    if (sizeof($images) == 0){
+      echo "(No scans found)<br><br>";
+      continue;
+    }
+
+    echo "<table cellspacing='5'><tr>";
+    foreach ($images as $img){
+      $full_id = $img[0];
+      $small_id = $img[1];
+      $time = format_time($img[2]);
+      echo "<td><center><a href=\"ns_view_image.php?image_id=$full_id\">";
+      echo "<img src=\"ns_view_image.php?image_id=$small_id&redirect=1\" alt=\"Scan\" width=\"200\"/></a><br>";
+      echo "<font size='-1'>$time</font></center></td>";
+    }
+    echo "</tr></table><br>";
+  }
+
+  display_worm_page_footer();
+}
+catch(ns_exception $ex){
+  die($ex->text);
+}
+?>

--- a/website/image_server_web/view_scanner_activity.php
+++ b/website/image_server_web/view_scanner_activity.php
@@ -68,6 +68,7 @@ for ($i = 0; $i < sizeof($exper); $i++)
 
 display_worm_page_header("Imaging Cluster Activity");
 ?>
+<a href="view_recent_scans.php">[View Recent Scans]</a><br><br>
 <table width="100%">
 <TR><td valign="top" align="center" width="50%"><center>
 	<table bgcolor="#555555" cellspacing='0' cellpadding='1' >


### PR DESCRIPTION
## Summary
- add `view_recent_scans.php` to list the four most recent captured images for each scanner
- link to recent scan view from scanner activity page

## Testing
- `php -l website/image_server_web/view_recent_scans.php`
- `php -l website/image_server_web/view_scanner_activity.php`


------
https://chatgpt.com/codex/tasks/task_e_689cd65dc5388324ac22934d2db0a8d3