### PR TITLE
Enable multi-threaded processing worker pool

### DIFF
--- a/ns_image_server/image_acquisition/ns_image_server_dispatcher.cpp
+++ b/ns_image_server/image_acquisition/ns_image_server_dispatcher.cpp
@@ -39,7 +39,26 @@ void ns_image_server_dispatcher::init(const unsigned int port,const unsigned int
 }
 
 void ns_image_server_dispatcher::connect_timer_sql_connection(){
-		timer_sql_connection = image_server.new_sql_connection(__FILE__,__LINE__);
+                timer_sql_connection = image_server.new_sql_connection(__FILE__,__LINE__);
+}
+
+void ns_image_server_dispatcher::initialize_processing_thread_pool(){
+        if (processing_threads_initialized)
+                return;
+
+        max_simultaneous_processing_threads = image_server.processing_threads_per_machine();
+        if (max_simultaneous_processing_threads == 0)
+                max_simultaneous_processing_threads = 1;
+
+        processing_threads.resize(max_simultaneous_processing_threads,0);
+        processing_thread_contexts.resize(max_simultaneous_processing_threads);
+        job_schedulers.resize(max_simultaneous_processing_threads,0);
+        for (unsigned int i = 0; i < max_simultaneous_processing_threads; ++i){
+                processing_threads[i] = new ns_single_thread_coordinator;
+                processing_thread_contexts[i] = ns_processing_thread_context(this,i);
+                job_schedulers[i] = new ns_processing_job_scheduler(image_server);
+        }
+        processing_threads_initialized = true;
 }
 ns_thread_return_type handle_dispatcher_request(void * d){
 	ns_image_server_dispatcher * dispatcher(static_cast<ns_image_server_dispatcher *>(d));
@@ -367,21 +386,32 @@ void ns_image_server_dispatcher::handle_delayed_exception(){
 	}
 }
 void ns_image_server_dispatcher::clear_for_termination(){
-	ns_acquire_lock_for_scope lock(processing_lock,__FILE__,__LINE__);
-	if (processing_thread.is_running())
-		processing_thread.block_on_finish();
-	if (schedule_error_check_thread.is_running())
-		schedule_error_check_thread.block_on_finish();
-	lock.release();
-	//ns_safe_delete(processing_thread);
-	ns_safe_delete(delayed_exception);
-	
-	ns_acquire_lock_for_scope work_lock(work_sql_management_lock,__FILE__,__LINE__);
-	ns_safe_delete(work_sql_connection);
-	work_lock.release();
-	ns_acquire_lock_for_scope timer_lock(timer_sql_management_lock,__FILE__,__LINE__);
-	ns_safe_delete(timer_sql_connection);
-	timer_lock.release();
+        ns_acquire_lock_for_scope lock(processing_lock,__FILE__,__LINE__);
+        if (processing_threads_initialized){
+                for (unsigned int i = 0; i < processing_threads.size(); ++i){
+                        if (processing_threads[i] != 0 && processing_threads[i]->is_running())
+                                processing_threads[i]->block_on_finish();
+                }
+        }
+        if (schedule_error_check_thread.is_running())
+                schedule_error_check_thread.block_on_finish();
+        lock.release();
+        ns_safe_delete(delayed_exception);
+
+        if (processing_threads_initialized){
+                for (unsigned int i = 0; i < job_schedulers.size(); ++i)
+                        ns_safe_delete(job_schedulers[i]);
+                for (unsigned int i = 0; i < processing_threads.size(); ++i)
+                        ns_safe_delete(processing_threads[i]);
+                processing_threads.clear();
+                processing_thread_contexts.clear();
+                job_schedulers.clear();
+                processing_threads_initialized = false;
+        }
+
+        ns_acquire_lock_for_scope timer_lock(timer_sql_management_lock,__FILE__,__LINE__);
+        ns_safe_delete(timer_sql_connection);
+        timer_lock.release();
 }
 ns_image_server_dispatcher::~ns_image_server_dispatcher(){
 	clear_for_termination();
@@ -389,14 +419,22 @@ ns_image_server_dispatcher::~ns_image_server_dispatcher(){
 
 void ns_image_server_dispatcher::wait_for_local_jobs(){
 	
-	ns_acquire_lock_for_scope lock(processing_lock,__FILE__,__LINE__);
-	if (processing_thread.is_running()){
-		image_server.register_server_event(ns_image_server::ns_register_in_central_db_with_fallback,ns_image_server_event("Exit requested.  Waiting for local jobs to finish..."));
-		processing_thread.block_on_finish();
-	}
-	lock.release();
-	if(schedule_error_check_thread.is_running())
-		schedule_error_check_thread.block_on_finish();
+        ns_acquire_lock_for_scope lock(processing_lock,__FILE__,__LINE__);
+        bool waiting_for_jobs(false);
+        if (processing_threads_initialized){
+                for (unsigned int i = 0; i < processing_threads.size(); ++i){
+                        if (processing_threads[i] != 0 && processing_threads[i]->is_running()){
+                                if (!waiting_for_jobs){
+                                        image_server.register_server_event(ns_image_server::ns_register_in_central_db_with_fallback,ns_image_server_event("Exit requested.  Waiting for local jobs to finish..."));
+                                        waiting_for_jobs = true;
+                                }
+                                processing_threads[i]->block_on_finish();
+                        }
+                }
+        }
+        lock.release();
+        if(schedule_error_check_thread.is_running())
+                schedule_error_check_thread.block_on_finish();
 	image_server.wait_for_pending_threads();
 	image_server.device_manager.wait_for_all_scans_to_complete();
 	buffered_capture_scheduler.image_capture_data_manager.wait_for_transfer_finish();
@@ -408,21 +446,30 @@ void ns_image_server_dispatcher::start_looking_for_new_work(){
 		return;
 	}
 	//ns_sql * sql = image_server.new_sql_connection();
-	try{
-		//when a processing thread is running, its handle is stored in processing_thread.
-		ns_acquire_lock_for_scope lock(processing_lock,__FILE__,__LINE__);
-		if (allow_processing && !processing_thread.is_running()){
-			//get a job from the server
-			cerr << ".";
-			processing_thread.run(thread_start_look_for_work,this);
-		}
-		else cerr << ":";
-		lock.release();
-	}
-	catch(std::exception & exception){
-		ns_ex ex(exception);
-		throw ex;
-	}
+        try{
+                ns_acquire_lock_for_scope lock(processing_lock,__FILE__,__LINE__);
+                if (!processing_threads_initialized)
+                        initialize_processing_thread_pool();
+
+                if (allow_processing && !image_server.exit_requested){
+                        bool started_job(false);
+                        for (unsigned int i = 0; i < processing_threads.size(); ++i){
+                                if (processing_threads[i] != 0 && !processing_threads[i]->is_running()){
+                                        processing_threads[i]->run(thread_start_look_for_work,&processing_thread_contexts[i]);
+                                        cerr << ".";
+                                        started_job = true;
+                                }
+                        }
+                        if (!started_job)
+                                cerr << ":";
+                }
+                else cerr << ":";
+                lock.release();
+        }
+        catch(std::exception & exception){
+                ns_ex ex(exception);
+                throw ex;
+        }
 }
 
 void ns_image_server_dispatcher::handle_central_connection_error(ns_ex & ex){
@@ -847,21 +894,27 @@ void ns_image_server_dispatcher::on_timer(){
 		}
 		try{
 			if (image_server.current_sql_database() != database_requested){
-				try{
-					ns_acquire_lock_for_scope lock(processing_lock,__FILE__,__LINE__);
-					if (processing_thread.is_running()){
-						image_server.register_server_event(ns_image_server::ns_register_in_central_db,ns_image_server_event("Database Change Requested: waiting for jobs to finish."));
-						processing_thread.block_on_finish();
-					}
-					image_server.set_sql_database(database_requested);
-					if (work_sql_connection!=0)
-						work_sql_connection->select_db(image_server.current_sql_database());
-					if (timer_sql_connection!=0)
-					timer_sql_connection->select_db(image_server.current_sql_database());
+                                try{
+                                        ns_acquire_lock_for_scope lock(processing_lock,__FILE__,__LINE__);
+                                        if (processing_threads_initialized){
+                                                bool notified(false);
+                                                for (unsigned int i = 0; i < processing_threads.size(); ++i){
+                                                        if (processing_threads[i] != 0 && processing_threads[i]->is_running()){
+                                                                if (!notified){
+                                                                        image_server.register_server_event(ns_image_server::ns_register_in_central_db,ns_image_server_event("Database Change Requested: waiting for jobs to finish."));
+                                                                        notified = true;
+                                                                }
+                                                                processing_threads[i]->block_on_finish();
+                                                        }
+                                                }
+                                        }
+                                        image_server.set_sql_database(database_requested);
+                                        if (timer_sql_connection!=0)
+                                                timer_sql_connection->select_db(image_server.current_sql_database());
 
-					lock.release();
+                                        lock.release();
 
-				}
+                                }
 				catch(...){
 					timer_sql_connection->clear_query();
 					*timer_sql_connection << "UPDATE hosts SET database_used = '" << image_server.current_sql_database() << "' WHERE id=" << image_server.host_id();
@@ -1028,76 +1081,73 @@ void ns_image_server_dispatcher::recieve_image_thread(ns_image_server_message & 
 //Look for plate image capture jobs on remote machines.
 //All the BEGINing and COMMITing maintains atomic nature
 //of job picking
-bool ns_image_server_dispatcher::look_for_work(){
-	bool action_performed(false);
-	ns_acquire_lock_for_scope sql_lock(work_sql_management_lock,__FILE__,__LINE__);
-	if (work_sql_connection == 0){
-		work_sql_connection = image_server.new_sql_connection(__FILE__,__LINE__);
-	}else{
-		//clear any dangling transactions
-		work_sql_connection->set_autocommit(true);
-		work_sql_connection->send_query("ROLLBACK");
-	}
-	try{
-		work_sql_connection->clear_query();
-		work_sql_connection->check_connection();
-	}
-	catch(ns_ex & ex){
-		ns_image_server_event ev;
-		ev << "Lost connection to mySQL server.  Reconnecting..." << ns_ts_sql_error;
-		image_server.register_server_event_no_db(ev);
-		ns_safe_delete(work_sql_connection);
-		work_sql_connection = image_server.new_sql_connection(__FILE__,__LINE__);
-	}
-	sql_lock.release();
-	
-	try{
-		image_server.perform_experiment_maintenance(*work_sql_connection);
-		//search the server for an image processing task
-		const bool first_in_first_out_job_queue (image_server.get_cluster_constant_value("job_queue_is_FIFO","false",work_sql_connection)!="false");
-		action_performed = job_scheduler.run_a_job(*work_sql_connection,first_in_first_out_job_queue);
-		if (action_performed)
-			register_succesful_operation();
-		work_sql_connection->send_query("COMMIT");
-		work_sql_connection->send_query("UNLOCK TABLES");
-		//if we're running as a screen saver, don't hog memory when
-		//the user is on the computer
-		if (!image_server.run_autonomously())
-			image_server.image_storage.cache.clear_memory_cache();
-		job_scheduler.clear_heap();
+bool ns_image_server_dispatcher::look_for_work(const unsigned int worker_id){
+        bool action_performed(false);
+        if (worker_id >= job_schedulers.size() || job_schedulers[worker_id] == 0)
+                return false;
 
-		//ns_thread::sleep(4*1000 + 39);
-		//cerr << "Done working.\n";
-		//notify the dispatcher that the current job is done.
-	}
-	catch(...){
+        ns_processing_job_scheduler & scheduler(*job_schedulers[worker_id]);
 
-		//any code needed to maintain lock integrity should go here
-		if (work_sql_connection!= 0){
-			work_sql_connection->send_query("COMMIT");
-			//con->disconnect();
-			//delete con;
-			//con = 0;
-		}
-		if (!image_server.run_autonomously())
-			image_server.image_storage.cache.clear_memory_cache();
-		throw;
-	}
-	return action_performed;
+        ns_acquire_for_scope<ns_sql> sql(image_server.new_sql_connection(__FILE__,__LINE__));
+        ns_sql * connection(&sql());
+        connection->set_autocommit(true);
+        connection->send_query("ROLLBACK");
+        try{
+                connection->clear_query();
+                connection->check_connection();
+        }
+        catch(ns_ex & ex){
+                ns_image_server_event ev;
+                ev << "Lost connection to mySQL server.  Reconnecting..." << ns_ts_sql_error;
+                image_server.register_server_event_no_db(ev);
+                sql.release();
+                sql.attach(image_server.new_sql_connection(__FILE__,__LINE__));
+                connection = &sql();
+                connection->set_autocommit(true);
+                connection->send_query("ROLLBACK");
+        }
+
+        try{
+                image_server.perform_experiment_maintenance(*connection);
+                const bool first_in_first_out_job_queue (image_server.get_cluster_constant_value("job_queue_is_FIFO","false",connection)!="false");
+                action_performed = scheduler.run_a_job(*connection,first_in_first_out_job_queue);
+                if (action_performed)
+                        register_succesful_operation();
+                connection->send_query("COMMIT");
+                connection->send_query("UNLOCK TABLES");
+                if (!image_server.run_autonomously())
+                        image_server.image_storage.cache.clear_memory_cache();
+                scheduler.clear_heap();
+        }
+        catch(...){
+                if (connection != 0)
+                        connection->send_query("COMMIT");
+                if (!image_server.run_autonomously())
+                        image_server.image_storage.cache.clear_memory_cache();
+                scheduler.clear_heap();
+                throw;
+        }
+        return action_performed;
 }
 
 void ns_image_server_dispatcher::register_succesful_operation(){
-	if (memory_allocation_error_count > 0)
-		memory_allocation_error_count--;
+        ns_acquire_lock_for_scope lock(memory_allocation_error_lock,__FILE__,__LINE__);
+        if (memory_allocation_error_count > 0)
+                memory_allocation_error_count--;
 }
 void ns_image_server_dispatcher::handle_memory_allocation_error(){
-	memory_allocation_error_count++;
-	image_server.image_storage.cache.clear_memory_cache();
-	if (memory_allocation_error_count > 5){
-		image_server.pause_host();	
-		ns_ex ex("The host has recently encountered too many memory errors.  The host will pause until futher notice.");
-		image_server.register_server_event(ns_image_server::ns_register_in_central_db,ex);
-	}
+        bool too_many(false);
+        {
+                ns_acquire_lock_for_scope lock(memory_allocation_error_lock,__FILE__,__LINE__);
+                memory_allocation_error_count++;
+                too_many = memory_allocation_error_count > 5;
+        }
+        image_server.image_storage.cache.clear_memory_cache();
+        if (too_many){
+                image_server.pause_host();
+                ns_ex ex("The host has recently encountered too many memory errors.  The host will pause until futher notice.");
+                image_server.register_server_event(ns_image_server::ns_register_in_central_db,ex);
+        }
 }
 
 ns_thread_return_type ns_asynch_start_looking_for_new_work(void * dispatcher_pointer){
@@ -1107,46 +1157,52 @@ ns_thread_return_type ns_asynch_start_looking_for_new_work(void * dispatcher_poi
 	return 0;
 }
 
-ns_thread_return_type ns_image_server_dispatcher::thread_start_look_for_work(void * dispatcher_pointer){
-	ns_image_server_dispatcher * d = reinterpret_cast<ns_image_server_dispatcher *>(dispatcher_pointer);
-	
-	bool found_work(false);
-	try{
-		try{
-			ns_thread current_thread (ns_thread::get_current_thread());
-			current_thread.set_priority(NS_THREAD_LOW);
-			found_work = d->look_for_work();
-		}
-		catch(std::exception & exception){
-			ns_ex ex(exception);
-			image_server.register_server_event(ns_image_server::ns_register_in_central_db,ex);
-			if (ex.type() == ns_memory_allocation)
-				d->handle_memory_allocation_error();			
-		}
-		
+ns_thread_return_type ns_image_server_dispatcher::thread_start_look_for_work(void * context_pointer){
+        ns_processing_thread_context * context = reinterpret_cast<ns_processing_thread_context *>(context_pointer);
+        ns_image_server_dispatcher * d = context->dispatcher;
+        const unsigned int worker_id(context->worker_id);
 
-		//ns_acquire_lock_for_scope lock(d->processing_lock,__FILE__,__LINE__);
-		d->processing_thread.report_as_finished();
-		//if we found work, immediately look for another job.
-		if (found_work && !image_server.exit_requested)
-			ns_thread start_looking_for_new_work(ns_asynch_start_looking_for_new_work,dispatcher_pointer);
+        bool found_work(false);
+        try{
+                try{
+                        ns_thread current_thread (ns_thread::get_current_thread());
+                        current_thread.set_priority(NS_THREAD_LOW);
+                        found_work = d->look_for_work(worker_id);
+                }
+                catch(std::exception & exception){
+                        ns_ex ex(exception);
+                        image_server.register_server_event(ns_image_server::ns_register_in_central_db,ex);
+                        if (ex.type() == ns_memory_allocation)
+                                d->handle_memory_allocation_error();
+                }
 
-		return 0;
-	}
-	catch(std::exception & exception){
-		ns_ex ex(exception);
-		//self.detach();
-        ex << ex.text() << "(Error in processing_thread)";
-			if (ex.type() == ns_memory_allocation)
-				image_server.image_storage.cache.clear_memory_cache();
-		
-		image_server.register_server_event(ns_image_server::ns_register_in_central_db_with_fallback,ex);
-		image_server.ns_image_server::shut_down_host();
+                {
+                        ns_acquire_lock_for_scope lock(d->processing_lock,__FILE__,__LINE__);
+                        if (worker_id < d->processing_threads.size() && d->processing_threads[worker_id] != 0)
+                                d->processing_threads[worker_id]->report_as_finished();
+                }
+                if (found_work && !image_server.exit_requested)
+                        ns_thread start_looking_for_new_work(ns_asynch_start_looking_for_new_work,d);
 
-		d->processing_thread.report_as_finished();
+                return 0;
+        }
+        catch(std::exception & exception){
+                ns_ex ex(exception);
+                ex << ex.text() << "(Error in processing_thread)";
+                if (ex.type() == ns_memory_allocation)
+                        image_server.image_storage.cache.clear_memory_cache();
 
-		return 0;
-	}
+                image_server.register_server_event(ns_image_server::ns_register_in_central_db_with_fallback,ex);
+                image_server.ns_image_server::shut_down_host();
+
+                {
+                        ns_acquire_lock_for_scope lock(d->processing_lock,__FILE__,__LINE__);
+                        if (worker_id < d->processing_threads.size() && d->processing_threads[worker_id] != 0)
+                                d->processing_threads[worker_id]->report_as_finished();
+                }
+
+                return 0;
+        }
 }
 ns_thread_return_type ns_scan_for_problems(void * d){
 

--- a/ns_image_server/image_acquisition/ns_image_server_dispatcher.h
+++ b/ns_image_server/image_acquisition/ns_image_server_dispatcher.h
@@ -38,11 +38,11 @@ class ns_image_server_dispatcher{
 public:
 	//allow_processing: whether the dispatcher should run imaging processing jobs
 	//note that initial compression of raw tifs is always performed regardless of allow_processing value.
-	ns_image_server_dispatcher(const bool _allow_processing):
-	  allow_processing(_allow_processing),delayed_exception(0),
-		  job_scheduler(image_server),processing_lock("ns_isd::processing"),first_device_capture_run(true),
-		  message_handling_lock("ns_isd::message"),memory_allocation_error_count(0),clean_clear_local_db_requested(false),
-		  hotplug_lock("ns_isd::hotplug"),device_capture_management_lock("ns_dml"),time_of_last_scan_for_problems(0),hotplug_running(false),work_sql_connection(0),currently_unable_to_connect_to_the_central_db(false),actively_avoid_connecting_to_central_db(false),timer_sql_connection(0),work_sql_management_lock("ns_isd::work_sql"),timer_sql_management_lock("ns_isd::timer_sql"),trigger_segfault(false){}
+        ns_image_server_dispatcher(const bool _allow_processing):
+          allow_processing(_allow_processing),delayed_exception(0),
+                  processing_lock("ns_isd::processing"),first_device_capture_run(true),
+                  message_handling_lock("ns_isd::message"),memory_allocation_error_count(0),memory_allocation_error_lock("ns_isd::mem_err"),clean_clear_local_db_requested(false),
+                  hotplug_lock("ns_isd::hotplug"),device_capture_management_lock("ns_dml"),time_of_last_scan_for_problems(0),hotplug_running(false),currently_unable_to_connect_to_the_central_db(false),actively_avoid_connecting_to_central_db(false),timer_sql_connection(0),timer_sql_management_lock("ns_isd::timer_sql"),trigger_segfault(false),max_simultaneous_processing_threads(1),processing_threads_initialized(false),random_number_seed(0){}
 
 	void init(const unsigned int port,const unsigned int socket_queue_length);
 	void register_device(const ns_device_name &device);
@@ -70,10 +70,10 @@ public:
 
 	void recieve_image(ns_image_server_message & message,ns_socket_connection & con);
 
-	//returns true if work was found
-	bool  look_for_work();
+        //returns true if work was found
+        bool  look_for_work(const unsigned int worker_id);
 
-	static ns_thread_return_type thread_start_look_for_work(void * dispatcher_pointer);
+        static ns_thread_return_type thread_start_look_for_work(void * context_pointer);
 
 	static ns_thread_return_type thread_start_recieving_image(void * recieve_info);
 
@@ -96,8 +96,17 @@ public:
 	unsigned long time_of_last_scan_for_problems;
 
 private:
-	bool trigger_segfault;
-	void handle_central_connection_error(ns_ex & ex);	
+        struct ns_processing_thread_context{
+                ns_processing_thread_context():dispatcher(0),worker_id(0){}
+                ns_processing_thread_context(ns_image_server_dispatcher * d, unsigned int id):dispatcher(d),worker_id(id){}
+                ns_image_server_dispatcher * dispatcher;
+                unsigned int worker_id;
+        };
+
+        void initialize_processing_thread_pool();
+
+        bool trigger_segfault;
+        void handle_central_connection_error(ns_ex & ex);
 	void recieve_image_thread(ns_image_server_message & message);
 	void scan_for_problems(ns_sql & sql);
 	void handle_memory_allocation_error();
@@ -107,15 +116,18 @@ private:
 
 	bool clean_clear_local_db_requested;
 
-	ns_single_thread_coordinator processing_thread;
-	ns_single_thread_coordinator message_handling_thread;
+        std::vector<ns_single_thread_coordinator *> processing_threads;
+        std::vector<ns_processing_thread_context> processing_thread_contexts;
+        std::vector<ns_processing_job_scheduler *> job_schedulers;
+        unsigned long max_simultaneous_processing_threads;
+        bool processing_threads_initialized;
+        ns_single_thread_coordinator message_handling_thread;
 
-	ns_lock message_handling_lock;
-	ns_lock device_capture_management_lock;
+        ns_lock message_handling_lock;
+        ns_lock device_capture_management_lock;
 
-	ns_lock work_sql_management_lock;
-	ns_lock timer_sql_management_lock;
-	std::list<ns_remote_dispatcher_request> pending_remote_requests;
+        ns_lock timer_sql_management_lock;
+        std::list<ns_remote_dispatcher_request> pending_remote_requests;
 
 	bool currently_unable_to_connect_to_the_central_db;
 	bool actively_avoid_connecting_to_central_db;
@@ -128,16 +140,14 @@ private:
 	void wait_for_local_jobs();
 	void run_hotplug(const bool rescan_bad_barcodes=true,const bool verbose=true);
 
-	ns_processing_job_scheduler job_scheduler;
+        ns_lock processing_lock;
+        ns_lock memory_allocation_error_lock;
+        ns_lock hotplug_lock;
+        bool hotplug_running;
 
-	ns_lock processing_lock;
-	ns_lock hotplug_lock;
-	bool hotplug_running;
+        unsigned int random_number_seed;
 
-	unsigned int random_number_seed;
-
-	ns_sql * work_sql_connection,
-		   * timer_sql_connection;
+        ns_sql * timer_sql_connection;
 };
 
 

--- a/ns_image_server/image_server/ns_image_server.cpp
+++ b/ns_image_server/image_server/ns_image_server.cpp
@@ -31,11 +31,11 @@ using namespace std;
 void ns_image_server_global_debug_handler(const ns_text_stream_t & t);
 
 ns_image_server::ns_image_server():event_log_open(false),exit_requested(false),update_software(false),
-	sql_lock("ns_is::sql"),server_event_lock("ns_is::server_event"),simulator_scan_lock("ns_is::sim_scan"),local_buffer_sql_lock("ns_is::lb"),
-	_act_as_processing_node(true),cleared(false),current_sql_server_address_id(0),
-	image_registration_profile_cache(1024*4), //allocate 4 gigabytes of disk space in which to store reference images for capture sample registration
-	_verbose_debug_output(false),_cache_subdirectory("cache"),sql_database_choice(possible_sql_databases.end()),next_scan_for_problems_time(0),
-_terminal_window_scale_factor(1){
+        sql_lock("ns_is::sql"),server_event_lock("ns_is::server_event"),simulator_scan_lock("ns_is::sim_scan"),local_buffer_sql_lock("ns_is::lb"),
+        _act_as_processing_node(true),cleared(false),current_sql_server_address_id(0),
+        image_registration_profile_cache(1024*4), //allocate 4 gigabytes of disk space in which to store reference images for capture sample registration
+        _verbose_debug_output(false),_cache_subdirectory("cache"),sql_database_choice(possible_sql_databases.end()),next_scan_for_problems_time(0),
+_terminal_window_scale_factor(1),processing_threads_per_machine_(1){
 
 	ns_socket::global_init();
 	ns_worm_detection_constants::init();
@@ -1872,7 +1872,8 @@ void ns_image_server::load_constants(const ns_image_server::ns_image_server_exec
 
 	constants.start_specification_group(ns_ini_specification_group("Image Analysis Server Settings ","These settings control the behavior of image processing servers"));
 	constants.add_field("act_as_processing_node","yes","Should the server run image processing jobs requested by the user via the website? (yes / no)");
-	constants.add_field("nodes_per_machine", "1","A single computer can run multiple copies of the image processing server simultaneously, which allows many jobs to be processed in parallel.  Set this value to the number of parallel servers you want to run on this machine.  This can usually be set to the number of physical cores on the machine's processor, or the number of GB of RAM on the machine; whichever is smaller.");
+        constants.add_field("nodes_per_machine", "1","A single computer can run multiple copies of the image processing server simultaneously, which allows many jobs to be processed in parallel.  Set this value to the number of parallel servers you want to run on this machine.  This can usually be set to the number of physical cores on the machine's processor, or the number of GB of RAM on the machine; whichever is smaller.");
+        constants.add_field("processing_threads_per_machine","0","Number of processing threads each server process should launch.  Leave this set to 0 to match the nodes_per_machine value, or set it to a positive integer to override the number of concurrent jobs a process can execute.");
 	constants.add_field("hide_window","no","On windows, specifies whether the server should start minimized.  (yes / no )");
 	constants.add_field("compile_videos","no","Should the server process videos? (yes / no)");
 	constants.add_field("video_compiler_filename","./x264.exe","Path to the x264 transcoder program required to generate videos.  Only needed on image processing servers.  If you don't have this, set compile_videos to no");
@@ -2009,7 +2010,17 @@ void ns_image_server::load_constants(const ns_image_server::ns_image_server_exec
 			throw ns_ex("Host names must be 15 characters or less.  \"") << host_name << "\" is " << host_name.size() << " characters.";
 		base_host_name			= constants["host_name"];
 		host_name				= opt.host_name(base_host_name);
-		number_of_node_processes_per_machine_ = atol(constants["nodes_per_machine"].c_str());
+                number_of_node_processes_per_machine_ = atol(constants["nodes_per_machine"].c_str());
+                processing_threads_per_machine_ = number_of_node_processes_per_machine_;
+                if (constants.field_specified("processing_threads_per_machine")){
+                        long specified_threads = atol(constants["processing_threads_per_machine"].c_str());
+                        if (specified_threads > 0)
+                                processing_threads_per_machine_ = specified_threads;
+                        else if (specified_threads == 0)
+                                processing_threads_per_machine_ = number_of_node_processes_per_machine_;
+                }
+                if (processing_threads_per_machine_ == 0)
+                        processing_threads_per_machine_ = 1;
 		volatile_storage_directory	= opt.volatile_storage(ns_dir::format_path(constants["volatile_storage_directory"]));
 		_dispatcher_port		= opt.port(atoi(constants["dispatcher_port"].c_str()));
 		_act_as_an_image_capture_server = ( ns_to_bool(constants["act_as_image_capture_server"]) && opt.manage_capture_devices);

--- a/ns_image_server/image_server/ns_image_server.h
+++ b/ns_image_server/image_server/ns_image_server.h
@@ -401,7 +401,8 @@ public:
 
 	ns_alert_handler alert_handler;
 	void register_alerts_as_handled();
-	unsigned long number_of_node_processes_per_machine() const{ return number_of_node_processes_per_machine_;}
+        unsigned long number_of_node_processes_per_machine() const{ return number_of_node_processes_per_machine_;}
+        unsigned long processing_threads_per_machine() const{ return processing_threads_per_machine_;}
 	unsigned handle_software_updates()const{return multiprocess_control_options.handle_software_updates;}
 
 	
@@ -441,7 +442,8 @@ public:
 	ns_process_priority process_priority;
 private:
 	ns_multiprocess_control_options multiprocess_control_options;
-	unsigned long number_of_node_processes_per_machine_;
+        unsigned long number_of_node_processes_per_machine_;
+        unsigned long processing_threads_per_machine_;
 	bool alert_handler_running;
 	//ns_lock alert_handler_lock;
 	ns_single_thread_coordinator alert_handler_thread;


### PR DESCRIPTION
## Summary
- replace the dispatcher’s single processing worker with a pool of coordinators that can launch multiple jobs concurrently, including per-thread schedulers and SQL connections
- ensure dispatcher shutdown and database switching wait for all active workers before proceeding
- add a configurable `processing_threads_per_machine` setting so operators can control per-process concurrency while preserving existing defaults

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb212c434c8324b92004ccc7aebf75